### PR TITLE
hidl: livedisplay: Fix reading mode string comparison

### DIFF
--- a/lineagehw/hidl/livedisplay/ReadingEnhancement.cpp
+++ b/lineagehw/hidl/livedisplay/ReadingEnhancement.cpp
@@ -47,7 +47,7 @@ Return<bool> ReadingEnhancement::isEnabled() {
         contents = Trim(contents);
     }
 
-    return !contents.compare("Current accessibility : DSI0 : GRAYSCALE ") || !contents.compare("4");
+    return !contents.compare("Current accessibility : DSI0 : GRAYSCALE") || !contents.compare("4");
 }
 
 Return<bool> ReadingEnhancement::setEnabled(bool enabled) {


### PR DESCRIPTION
* Since we are trimming the string it will
  never match one with trailing space at the end.

Change-Id: Iea76092112555ed8b858560f07ef8e88f0ff593b